### PR TITLE
Fix: unable to load fonts without VPN

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -54,6 +54,9 @@ export default defineNuxtConfig({
     mode: 'css',
     cssLayer: 'base'
   },
+  fonts: {
+    provider: "google",
+  },
   nitro: {
     routeRules: {
       '/distant-api/**': { proxy: `${process.env.NUXT_PUBLIC_BACKEND_URL || 'https://api.helicraft.ru'}/**` },


### PR DESCRIPTION
Fixed messages wihout VPN
`WARN  Could not fetch from https://api.fontshare.com/v2/fonts?offset=0&limit=100. Will retry in 1000ms. 3 retries left.`                                                                                              